### PR TITLE
support for generic lists

### DIFF
--- a/src/test/java/eu/dozd/mongo/MongoMapperIT.java
+++ b/src/test/java/eu/dozd/mongo/MongoMapperIT.java
@@ -7,6 +7,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -265,5 +266,33 @@ public class MongoMapperIT extends AbstractMongoIT {
         Assert.assertTrue(returned.getBools().containsKey("b1"));
         Assert.assertTrue(returned.getBools().containsKey("b2"));
         Assert.assertEquals(bools.get("b1"), returned.getBools().get("b1"));
+    }
+
+    @Test
+    public void testGenericList() {
+        MongoCollection<TestEntityList> collection = db.getCollection("test_list", TestEntityList.class);
+        collection.drop();
+
+        TestEntityEmbedded embeddedEntity1 = new TestEntityEmbedded();
+        embeddedEntity1.setName("Entity 1");
+        embeddedEntity1.setAge(1);
+
+        TestEntityEmbedded embeddedEntity2 = new TestEntityEmbedded();
+        embeddedEntity2.setName("Entity 2");
+        embeddedEntity2.setAge(2);
+
+        ArrayList<TestEntityEmbedded> list = new ArrayList<>();
+        list.add(embeddedEntity1);
+        list.add(embeddedEntity2);
+
+        TestEntityList entity = new TestEntityList();
+        entity.setList(list);
+
+        collection.insertOne(entity);
+
+        TestEntityList returned = collection.find().first();
+        Assert.assertEquals(entity.getList().size(), entity.getList().size());
+        Assert.assertEquals(entity.getList().get(0), returned.getList().get(0));
+        Assert.assertEquals(entity.getList().get(1), returned.getList().get(1));
     }
 }

--- a/src/test/java/eu/dozd/mongo/entity/TestEntityList.java
+++ b/src/test/java/eu/dozd/mongo/entity/TestEntityList.java
@@ -1,0 +1,56 @@
+package eu.dozd.mongo.entity;
+
+import eu.dozd.mongo.annotation.Entity;
+import eu.dozd.mongo.annotation.Id;
+
+import java.util.List;
+
+@Entity
+public class TestEntityList {
+    @Id
+    private String id;
+    private boolean checked;
+    private String name;
+    private Integer j;
+    private List<TestEntityEmbedded> list;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public boolean isChecked() {
+        return checked;
+    }
+
+    public void setChecked(boolean checked) {
+        this.checked = checked;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getJ() {
+        return j;
+    }
+
+    public void setJ(Integer j) {
+        this.j = j;
+    }
+
+    public List<TestEntityEmbedded> getList() {
+        return list;
+    }
+
+    public void setList(List<TestEntityEmbedded> list) {
+        this.list = list;
+    }
+}


### PR DESCRIPTION
Hi,
i added support for generic lists, however it can be that the code needs some refactoring :) 
I have tested it locally and it worked, maybe i will add tests at the weekend.

I tested List, List<MyClass>, as well as Lists in Childclasses.

Now the following statement is possible:

```java
List<MyClass> myList = classRetrievedFromMongoDb.getMyList();
MyClass myClass = myList.get(0);
```


