### PR TITLE
Non null annotation support

### DIFF
--- a/src/main/java/eu/dozd/mongo/EntityCodec.java
+++ b/src/main/java/eu/dozd/mongo/EntityCodec.java
@@ -181,9 +181,14 @@ class EntityCodec<T> implements CollectibleCodec<T> {
             } else if (info.getFieldType(field).isEnum()) {
                 Enum anEnum = (Enum) info.getValue(t, field);
                 String value = (anEnum == null) ? null : anEnum.name();
-                document.put(field, value);
+                if (value != null || !info.isNonNull(field)) {
+                    document.put(field, value);
+                }
             } else {
-                document.put(field, info.getValue(t, field));
+                Object value = info.getValue(t, field);
+                if (value != null || !info.isNonNull(field)) {
+                    document.put(field, info.getValue(t, field));
+                }
             }
         }
 

--- a/src/main/java/eu/dozd/mongo/annotation/NonNull.java
+++ b/src/main/java/eu/dozd/mongo/annotation/NonNull.java
@@ -1,0 +1,8 @@
+package eu.dozd.mongo.annotation;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface NonNull {
+}

--- a/src/test/java/eu/dozd/mongo/EntityInfoTest.java
+++ b/src/test/java/eu/dozd/mongo/EntityInfoTest.java
@@ -46,4 +46,10 @@ public class EntityInfoTest {
         Assert.assertTrue(info.hasField("name"));
         Assert.assertFalse(info.hasField("name2"));
     }
+
+    @Test
+    public void testIsNonNull() throws Exception {
+        Assert.assertTrue(info.isNonNull("j"));
+        Assert.assertFalse(info.isNonNull("name"));
+    }
 }

--- a/src/test/java/eu/dozd/mongo/MongoMapperIT.java
+++ b/src/test/java/eu/dozd/mongo/MongoMapperIT.java
@@ -2,6 +2,7 @@ package eu.dozd.mongo;
 
 import com.mongodb.client.MongoCollection;
 import eu.dozd.mongo.entity.*;
+import org.bson.*;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -117,6 +118,32 @@ public class MongoMapperIT extends AbstractMongoIT {
         Assert.assertNull(returned.getName());
         Assert.assertEquals(entity.getI(), returned.getI());
         Assert.assertNull(returned.getJ());
+    }
+
+    @Test
+    public void testNonNull() {
+        MongoCollection<TestEntity> collection = db.getCollection("test_nonnull", TestEntity.class);
+        collection.drop();
+
+        TestEntity entity = new TestEntity();
+        entity.setChecked(true);
+        entity.setName(null);
+        entity.setI(2);
+        entity.setJ(null);
+
+        collection.insertOne(entity);
+
+        TestEntity returned = collection.find().first();
+        Assert.assertEquals(entity.isChecked(), returned.isChecked());
+        Assert.assertNull(returned.getName());
+        Assert.assertEquals(entity.getI(), returned.getI());
+        Assert.assertNull(returned.getJ());
+
+        MongoCollection<Document> documentCollection = db.getCollection("test_nonnull", Document.class);
+        Document document = documentCollection.find().first();
+        Assert.assertTrue(document.containsKey("name"));
+        Assert.assertTrue(document.containsKey("i"));
+        Assert.assertFalse(document.containsKey("j"));
     }
 
     @Test

--- a/src/test/java/eu/dozd/mongo/entity/TestEntity.java
+++ b/src/test/java/eu/dozd/mongo/entity/TestEntity.java
@@ -1,7 +1,6 @@
 package eu.dozd.mongo.entity;
 
-import eu.dozd.mongo.annotation.Entity;
-import eu.dozd.mongo.annotation.Id;
+import eu.dozd.mongo.annotation.*;
 
 import java.util.Map;
 
@@ -13,6 +12,7 @@ public class TestEntity {
     private int i;
     private boolean checked;
     private String name;
+    @NonNull
     private Integer j;
     private Map<String, Integer> map;
 


### PR DESCRIPTION
This PR adds non null annotation support (like on jackson). 

If annotation is present on class, field or getter null values are not written to the MongoDB document.